### PR TITLE
From [Dev threading] into [Master]: First version release (v.1.1.0)

### DIFF
--- a/nionswift_plugin/laser_mod/gain_inst.py
+++ b/nionswift_plugin/laser_mod/gain_inst.py
@@ -93,25 +93,23 @@ class gainDevice(Observable.Observable):
 
     def acqThread(self):
         self.__status = True #started
+        self.__cur_wav = self.__start_wav
         self.upt()
 
-
         self.__abort_force = False
-        self.__cur_wav = self.__start_wav
         self.__laser.set_scan(self.__cur_wav, self.__step_wav, self.__pts) #THIS IS A THREAD. Start and bye
         data = []
         i=0
         while(not self.__laser.setWL_thread_check() and not self.__abort_force):
             data.append([])
-            logging.info(str(self.__cur_wav)+str(self.__laser.setWL_thread_locked()))
             while(  ( not self.__laser.setWL_thread_locked() and not self.__laser.setWL_thread_check())    and not self.__abort_force):
                 data[i].append(self.__camera.grab_next_to_finish()[0])
             i+=1
             if (self.__laser.setWL_thread_locked()):
                 self.__laser.setWL_thread_release() #if you dont release thread does not advance. 
+                self.__cur_wav += self.__step_wav
             self.upt()
         self.__camera.stop_playing()
-        logging.info(len(data))
         self.__stored = True and not self.__abort_force
         self.__status = False #its over
 
@@ -129,9 +127,8 @@ class gainDevice(Observable.Observable):
                 self.property_changed_event.fire("pts_f")
                 self.property_changed_event.fire("tpts_f")
                 self.property_changed_event.fire("cur_wav_f")
-            if message==3:
-                self.__cur_wav += self.__step_wav
-                #self.__laser.setWL_thread_release()
+            #if message==3:
+            #    logging.info("Step over")
             #if message==4:
                 #logging.info("msg 4")
         return sendMessage

--- a/nionswift_plugin/laser_mod/gain_panel.py
+++ b/nionswift_plugin/laser_mod/gain_panel.py
@@ -112,7 +112,7 @@ class gainView:
         self.acq_pb=ui.create_push_button(text="Acquire", name="acq_pb", on_clicked="acq_push")
         self.gen_pb=ui.create_push_button(text="Generate", name="gen_pb", on_clicked="gen_push")
         self.abt_pb=ui.create_push_button(text="Abort", name="abt_pb", on_clicked="abt_push")
-        self.ui_view6 = ui.create_row(self.upt_pb, self.acq_pb, self.gen_pb, self.abt_pb, spacing=12) #yves: Note that i removed update button. It is useless
+        self.ui_view6 = ui.create_row(self.acq_pb, self.gen_pb, self.abt_pb, spacing=12) #yves: Note that i removed update button. It is useless
 
         self.ui_view=ui.create_column(self.init_pb, self.ui_view1, self.ui_view2, self.ui_view3, self.ui_view4, self.ui_view5, self.ui_view6, spacing=1)
 

--- a/nionswift_plugin/laser_mod/laser_vi.py
+++ b/nionswift_plugin/laser_mod/laser_vi.py
@@ -59,15 +59,9 @@ class SirahCredoLaser:
     def setWL_thread(self, i_pts, step):
         if not self.abort_ctrl:
             self.lock.acquire()
-            if (i_pts==0):
-                logging.info("Scan has Begun")
-                latency = round(float(step)*1.0/20.0+0.25, 5)
-                time.sleep(latency)
-                self.sendmessage(5) #measurement of the first WL. You dont upgrade WL as in message 3
-            else:
-                latency = round(float(step)*1.0/20.0+0.25, 5)
-                time.sleep(latency)
-                self.sendmessage(3)
+            latency = round(float(step)*1.0/20.0+0.25, 5)
+            time.sleep(latency)
+            self.sendmessage(3)
             #self.lock.release()
         else:
             with self.lock:
@@ -81,7 +75,8 @@ class SirahCredoLaser:
         pool = ThreadPoolExecutor(1)
         for index in range(pts):
             self.thread = pool.submit(self.setWL_thread, index, step)
-
+        
+        self.setWL_thread_release()
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import os
 
 setuptools.setup(
     name="yvorsay-instrumentation_laser",
-    version="1.0.8",
+    version="1.1.0",
     author="Yves Auad",
     description="Laser Control",
     url="https://github.com/yvesauad/yvorsay-instrument",


### PR DESCRIPTION
First Release to Master from dev_threading [v.1.1.0]
-- Ideas are not perfect implemented but are all functional, specially
     - Acquire button going from start to finish taking into consideration camera dwell time and simulating real time laser hardware latency. In my case, i simple put a delay proportional to the wavelength step. 
     - Abort / Cancel button both in camera and laser. Looks functional for multiple operations
    - Camera independent from laser. Camera gets as much as frames possible. If dwell time (considering number of averages) is bigger than laser sweep mechanical time, a single frame is acquired. If dwell time is smaller, you accumulate frames while laser is moving. Please note that a single frame is preferable as most of your frames will be acquired in a static way (not with laser sweeping).

Next versions:
     - Implement power meter readout
          - including implement a ''real measurement'' with a real hardware
     - Implement demo mode for data output, including a power output
    - Remember last spectra, as in Lumiere, should be taken with laser OFF so we can always have a reference of "eels-only". Output data should take all this into consideration. PLease check my python script in Lumiere (altgether with DM script)